### PR TITLE
Add another note about permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,5 @@ modern macOS, you'll need to enable universal accessibility features
 to let this work.  It appears that you'll need to go to System
 Preferences > Privacy > Accessibility, and grant Terminal.app
 permission, not the `debounce` binary as you might expect.
+
+If you make changes to the code and r-build the debounce binary, you will have to manually remove and re-grant accessibility permissions for the app. Both `Accessibility` and `Input Monitoring` permisions are required.

--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ to let this work.  It appears that you'll need to go to System
 Preferences > Privacy > Accessibility, and grant Terminal.app
 permission, not the `debounce` binary as you might expect.
 
-If you make changes to the code and r-build the debounce binary, you will have to manually remove and re-grant accessibility permissions for the app. Both `Accessibility` and `Input Monitoring` permissions are required.
+If you make changes to the code and rebuild the debounce binary, you will have to manually remove and re-grant accessibility permissions for the app. Both `Accessibility` and `Input Monitoring` permissions are required.

--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ to let this work.  It appears that you'll need to go to System
 Preferences > Privacy > Accessibility, and grant Terminal.app
 permission, not the `debounce` binary as you might expect.
 
-If you make changes to the code and r-build the debounce binary, you will have to manually remove and re-grant accessibility permissions for the app. Both `Accessibility` and `Input Monitoring` permisions are required.
+If you make changes to the code and r-build the debounce binary, you will have to manually remove and re-grant accessibility permissions for the app. Both `Accessibility` and `Input Monitoring` permissions are required.


### PR DESCRIPTION
Every time I modify and rebuild my local copy of this, I have to spend an hour figuring out how to get the accessibility stuff working again. When you replace `/usr/local/bin/debounce`, you have to manually remove the privacy permission for `Accessibility` and for `Input Monitoring`. You'll be re-prompted to add them back.